### PR TITLE
Refactor: make ServiceImpl classes package-private (#9)

### DIFF
--- a/src/main/java/com/furkanerd/hr_management_system/service/impl/AttendanceServiceImpl.java
+++ b/src/main/java/com/furkanerd/hr_management_system/service/impl/AttendanceServiceImpl.java
@@ -29,7 +29,7 @@ import java.util.List;
 import java.util.UUID;
 
 @Service
-public class AttendanceServiceImpl implements AttendanceService {
+class AttendanceServiceImpl implements AttendanceService {
 
     private final AttendanceRepository attendanceRepository;
     private final AttendanceMapper attendanceMapper;

--- a/src/main/java/com/furkanerd/hr_management_system/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/furkanerd/hr_management_system/service/impl/AuthServiceImpl.java
@@ -31,7 +31,7 @@ import java.util.Random;
 import java.util.stream.Collectors;
 
 @Service
-public class AuthServiceImpl implements AuthService {
+class AuthServiceImpl implements AuthService {
 
     private final AuthenticationManager authenticationManager;
     private final UserDetailsService userDetailsService;

--- a/src/main/java/com/furkanerd/hr_management_system/service/impl/DepartmentServiceImpl.java
+++ b/src/main/java/com/furkanerd/hr_management_system/service/impl/DepartmentServiceImpl.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.UUID;
 
 @Service
-public class DepartmentServiceImpl implements DepartmentService {
+class DepartmentServiceImpl implements DepartmentService {
 
     private final DepartmentRepository departmentRepository;
     private final DepartmentMapper departmentMapper;

--- a/src/main/java/com/furkanerd/hr_management_system/service/impl/EmployeeServiceImpl.java
+++ b/src/main/java/com/furkanerd/hr_management_system/service/impl/EmployeeServiceImpl.java
@@ -35,7 +35,7 @@ import java.util.List;
 import java.util.UUID;
 
 @Service
-public class EmployeeServiceImpl implements EmployeeService {
+class EmployeeServiceImpl implements EmployeeService {
 
     private final EmployeeRepository employeeRepository;
     private final EmployeeMapper employeeMapper;

--- a/src/main/java/com/furkanerd/hr_management_system/service/impl/LeaveRequestServiceImpl.java
+++ b/src/main/java/com/furkanerd/hr_management_system/service/impl/LeaveRequestServiceImpl.java
@@ -33,7 +33,7 @@ import java.util.List;
 import java.util.UUID;
 
 @Service
-public class LeaveRequestServiceImpl implements LeaveRequestService {
+class LeaveRequestServiceImpl implements LeaveRequestService {
 
     private final LeaveRequestRepository leaveRequestRepository;
     private final LeaveRequestMapper leaveRequestMapper;

--- a/src/main/java/com/furkanerd/hr_management_system/service/impl/PerformanceReviewServiceImpl.java
+++ b/src/main/java/com/furkanerd/hr_management_system/service/impl/PerformanceReviewServiceImpl.java
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.UUID;
 
 @Service
-public class PerformanceReviewServiceImpl implements PerformanceReviewService {
+class PerformanceReviewServiceImpl implements PerformanceReviewService {
 
     private final PerformanceReviewRepository performanceReviewRepository;
     private final PerformanceReviewMapper performanceReviewMapper;

--- a/src/main/java/com/furkanerd/hr_management_system/service/impl/PositionServiceImpl.java
+++ b/src/main/java/com/furkanerd/hr_management_system/service/impl/PositionServiceImpl.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.UUID;
 
 @Service
-public class PositionServiceImpl implements PositionService {
+class PositionServiceImpl implements PositionService {
 
     private final PositionRepository positionRepository;
     private final PositionMapper positionMapper;

--- a/src/main/java/com/furkanerd/hr_management_system/service/impl/SalaryServiceImpl.java
+++ b/src/main/java/com/furkanerd/hr_management_system/service/impl/SalaryServiceImpl.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.UUID;
 
 @Service
-public class SalaryServiceImpl implements SalaryService {
+class SalaryServiceImpl implements SalaryService {
 
     private final SalaryRepository salaryRepository;
     private final SalaryMapper salaryMapper;


### PR DESCRIPTION
Changed ServiceImpl classes from public to package-private to reduce unnecessary visibility.
Closes #9 