### PR TITLE
refactor: reorganize controller endpoints by domain (#7)

### DIFF
--- a/src/main/java/com/furkanerd/hr_management_system/controller/AttendanceController.java
+++ b/src/main/java/com/furkanerd/hr_management_system/controller/AttendanceController.java
@@ -41,14 +41,14 @@ public class AttendanceController {
     )
     @GetMapping
     @PreAuthorize("hasAnyAuthority('ROLE_HR', 'ROLE_MANAGER')")
-    public ResponseEntity<ApiResponse<PaginatedResponse<ListAttendanceResponse>>> getAttendance(
-            @RequestParam(defaultValue = "0") @Min(0) int page ,
+    public ResponseEntity<ApiResponse<PaginatedResponse<ListAttendanceResponse>>> getAllAttendances(
+            @RequestParam(defaultValue = "0") @Min(0) int page,
             @RequestParam(defaultValue = "10") @Min(1) @Max(100) int size,
             @RequestParam(defaultValue = "date") String sortBy,
             @RequestParam(defaultValue = "desc") String sortDirection,
             AttendanceFilterRequest filterRequest
-    ){
-        PaginatedResponse<ListAttendanceResponse> responseList = attendanceService.listAllAttendance(page,size,sortBy,sortDirection,filterRequest);
+    ) {
+        PaginatedResponse<ListAttendanceResponse> responseList = attendanceService.listAllAttendance(page, size, sortBy, sortDirection, filterRequest);
         return ResponseEntity.ok(ApiResponse.success("Attendance records retrieved successfully", responseList));
     }
 
@@ -94,7 +94,7 @@ public class AttendanceController {
     )
     @PostMapping("/check-out")
     @PreAuthorize("hasAuthority('ROLE_EMPLOYEE')")
-    public ResponseEntity<ApiResponse<AttendanceDetailResponse>>  checkOut(@AuthenticationPrincipal UserDetails currentUser) {
+    public ResponseEntity<ApiResponse<AttendanceDetailResponse>> checkOut(@AuthenticationPrincipal UserDetails currentUser) {
         String employeeEmail = currentUser.getUsername();
         AttendanceDetailResponse checkedOut = attendanceService.autoCheckOut(employeeEmail);
         return ResponseEntity.ok(ApiResponse.success("Check-out successful", checkedOut));
@@ -110,7 +110,7 @@ public class AttendanceController {
     public ResponseEntity<ApiResponse<AttendanceDetailResponse>> updateAttendance(
             @PathVariable UUID id,
             @Valid @RequestBody AttendanceUpdateRequest updateRequest
-    ){
+    ) {
         AttendanceDetailResponse updated = attendanceService.updateAttendance(id, updateRequest);
         return ResponseEntity.ok(ApiResponse.success("Attendance record updated successfully", updated));
     }
@@ -124,15 +124,35 @@ public class AttendanceController {
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ApiResponse<PaginatedResponse<ListAttendanceResponse>>> getMyAttendances(
             @AuthenticationPrincipal UserDetails currentUser,
-            @RequestParam(defaultValue = "0") @Min(0) int page ,
+            @RequestParam(defaultValue = "0") @Min(0) int page,
             @RequestParam(defaultValue = "10") @Min(1) @Max(100) int size,
             @RequestParam(defaultValue = "date") String sortBy,
             @RequestParam(defaultValue = "desc") String sortDirection,
             AttendanceFilterRequest filterRequest
-    ){
+    ) {
         String employeeEmail = currentUser.getUsername();
-        PaginatedResponse<ListAttendanceResponse> responseList = attendanceService.getAttendanceByEmployee(employeeEmail,page,size,sortBy,sortDirection,filterRequest);
+        PaginatedResponse<ListAttendanceResponse> responseList = attendanceService.getAttendanceByEmployee(employeeEmail, page, size, sortBy, sortDirection, filterRequest);
         return ResponseEntity.ok(ApiResponse.success("My attendance records retrieved successfully", responseList));
+    }
+
+    @Operation(
+            summary = "Get employee attendance history",
+            description = "Retrieves the attendance history for a specific employee by ID. Accessible only to HR and Manager roles."
+    )
+    @GetMapping("/employee/{id}")
+    @PreAuthorize("hasAnyAuthority('ROLE_HR', 'ROLE_MANAGER')")
+    public ResponseEntity<ApiResponse<PaginatedResponse<ListAttendanceResponse>>> getEmployeeAttendanceHistory(
+            @PathVariable("id") UUID id,
+            @RequestParam(defaultValue = "0") @Min(0) int page,
+            @RequestParam(defaultValue = "10") @Min(1) @Max(100) int size,
+            @RequestParam(defaultValue = "date") String sortBy,
+            @RequestParam(defaultValue = "asc") String sortDirection,
+            AttendanceFilterRequest filterRequest
+    ) {
+        PaginatedResponse<ListAttendanceResponse> responseList = attendanceService
+                .getAllAttendanceByEmployee(id, page, size, sortBy, sortDirection, filterRequest);
+
+        return ResponseEntity.ok(ApiResponse.success(responseList));
     }
 
     @Operation(

--- a/src/main/java/com/furkanerd/hr_management_system/controller/DepartmentController.java
+++ b/src/main/java/com/furkanerd/hr_management_system/controller/DepartmentController.java
@@ -3,12 +3,10 @@ package com.furkanerd.hr_management_system.controller;
 import com.furkanerd.hr_management_system.model.dto.request.department.DepartmentCreateRequest;
 import com.furkanerd.hr_management_system.model.dto.request.department.DepartmentFilterRequest;
 import com.furkanerd.hr_management_system.model.dto.request.department.DepartmentUpdateRequest;
-import com.furkanerd.hr_management_system.model.dto.request.employee.EmployeeFilterRequest;
 import com.furkanerd.hr_management_system.model.dto.response.ApiResponse;
 import com.furkanerd.hr_management_system.model.dto.response.PaginatedResponse;
 import com.furkanerd.hr_management_system.model.dto.response.department.DepartmentDetailResponse;
 import com.furkanerd.hr_management_system.model.dto.response.department.ListDepartmentResponse;
-import com.furkanerd.hr_management_system.model.dto.response.employee.ListEmployeeResponse;
 import com.furkanerd.hr_management_system.service.DepartmentService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -42,14 +40,14 @@ public class DepartmentController {
     )
     @GetMapping
     @PreAuthorize("hasAuthority('ROLE_EMPLOYEE')")
-    public  ResponseEntity<ApiResponse<PaginatedResponse<ListDepartmentResponse>>> getAllDepartments(
-            @RequestParam(defaultValue = "0") @Min(0) int page ,
+    public ResponseEntity<ApiResponse<PaginatedResponse<ListDepartmentResponse>>> getAllDepartments(
+            @RequestParam(defaultValue = "0") @Min(0) int page,
             @RequestParam(defaultValue = "10") @Min(1) @Max(100) int size,
             @RequestParam(defaultValue = "name") String sortBy,
             @RequestParam(defaultValue = "asc") String sortDirection,
             DepartmentFilterRequest filterRequest
-    ){
-        PaginatedResponse<ListDepartmentResponse> departments = departmentService.listAllDepartments(page,size,sortBy,sortDirection,filterRequest);
+    ) {
+        PaginatedResponse<ListDepartmentResponse> departments = departmentService.listAllDepartments(page, size, sortBy, sortDirection, filterRequest);
         return ResponseEntity.ok(ApiResponse.success("Departments retrieved successfully", departments));
     }
 
@@ -65,30 +63,12 @@ public class DepartmentController {
     }
 
     @Operation(
-            summary = "Get all employees for a department",
-            description = "Retrieves a list of all employees working in a specific department. Accessible to HR and Manager roles."
-    )
-    @GetMapping("/{id}/employees")
-    @PreAuthorize("hasAnyAuthority('ROLE_HR', 'ROLE_MANAGER')")
-    public ResponseEntity<ApiResponse<PaginatedResponse<ListEmployeeResponse>>> getEmployeesByDepartment(
-            @PathVariable("id") UUID departmentId,
-            @RequestParam(defaultValue = "0") @Min(0) int page ,
-            @RequestParam(defaultValue = "10") @Min(1) @Max(100) int size,
-            @RequestParam(defaultValue = "firstName") String sortBy,
-            @RequestParam(defaultValue = "asc") String sortDirection,
-            EmployeeFilterRequest filterRequest
-    ){
-        PaginatedResponse<ListEmployeeResponse> responseList = departmentService.getEmployeesByDepartment(departmentId,page,size,sortBy,sortDirection,filterRequest);
-        return ResponseEntity.ok(ApiResponse.success("Employees retrieved for department successfully", responseList));
-    }
-
-    @Operation(
             summary = "Create a new department",
             description = "Creates a new department in the system. This action is restricted to users with the HR role."
     )
     @PostMapping
     @PreAuthorize("hasAuthority('ROLE_HR')")
-    public ResponseEntity<ApiResponse<DepartmentDetailResponse>> createDepartment(@Valid @RequestBody DepartmentCreateRequest departmentCreateRequest){
+    public ResponseEntity<ApiResponse<DepartmentDetailResponse>> createDepartment(@Valid @RequestBody DepartmentCreateRequest departmentCreateRequest) {
         DepartmentDetailResponse created = departmentService.createDepartment(departmentCreateRequest);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.success("Department created successfully", created));
@@ -101,8 +81,8 @@ public class DepartmentController {
     @PutMapping("/{id}")
     @PreAuthorize("hasAuthority('ROLE_HR')")
     public ResponseEntity<ApiResponse<DepartmentDetailResponse>> updateDepartment(
-            @PathVariable("id") UUID departmentId ,
-            @Valid @RequestBody DepartmentUpdateRequest departmentUpdateRequest){
+            @PathVariable("id") UUID departmentId,
+            @Valid @RequestBody DepartmentUpdateRequest departmentUpdateRequest) {
         DepartmentDetailResponse updated = departmentService.updateDepartment(departmentId, departmentUpdateRequest);
         return ResponseEntity.ok(ApiResponse.success("Department updated successfully", updated));
     }
@@ -113,7 +93,7 @@ public class DepartmentController {
     )
     @DeleteMapping("/{id}")
     @PreAuthorize("hasAuthority('ROLE_HR')")
-    public ResponseEntity<ApiResponse<Void>> deleteDepartment(@PathVariable("id") UUID departmentId){
+    public ResponseEntity<ApiResponse<Void>> deleteDepartment(@PathVariable("id") UUID departmentId) {
         departmentService.deleteDepartment(departmentId);
         return ResponseEntity.ok(ApiResponse.success("Department deleted successfully"));
     }

--- a/src/main/java/com/furkanerd/hr_management_system/controller/EmployeeController.java
+++ b/src/main/java/com/furkanerd/hr_management_system/controller/EmployeeController.java
@@ -1,22 +1,14 @@
 package com.furkanerd.hr_management_system.controller;
 
-import com.furkanerd.hr_management_system.model.dto.request.attendance.AttendanceFilterRequest;
+
 import com.furkanerd.hr_management_system.model.dto.request.employee.EmployeeFilterRequest;
 import com.furkanerd.hr_management_system.model.dto.request.employee.EmployeeUpdateRequest;
-import com.furkanerd.hr_management_system.model.dto.request.performancereview.PerformanceReviewFilterRequest;
-import com.furkanerd.hr_management_system.model.dto.request.salary.SalaryFilterRequest;
 import com.furkanerd.hr_management_system.model.dto.response.ApiResponse;
 import com.furkanerd.hr_management_system.model.dto.response.PaginatedResponse;
-import com.furkanerd.hr_management_system.model.dto.response.attendance.ListAttendanceResponse;
 import com.furkanerd.hr_management_system.model.dto.response.employee.EmployeeDetailResponse;
-import com.furkanerd.hr_management_system.model.dto.response.employee.EmployeeLeaveBalanceResponse;
 import com.furkanerd.hr_management_system.model.dto.response.employee.ListEmployeeResponse;
-import com.furkanerd.hr_management_system.model.dto.response.performancereview.ListPerformanceReviewResponse;
-import com.furkanerd.hr_management_system.model.dto.response.salary.ListSalaryResponse;
-import com.furkanerd.hr_management_system.model.entity.Employee;
 import com.furkanerd.hr_management_system.service.EmployeeService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
@@ -61,15 +53,15 @@ public class EmployeeController {
     )
     @GetMapping
     @PreAuthorize("hasAnyAuthority('ROLE_HR', 'ROLE_MANAGER')")
-    public ResponseEntity<ApiResponse<PaginatedResponse<ListEmployeeResponse>>>  getAllEmployees(
-            @RequestParam(defaultValue = "0") @Min(0) int page ,
+    public ResponseEntity<ApiResponse<PaginatedResponse<ListEmployeeResponse>>> getAllEmployees(
+            @RequestParam(defaultValue = "0") @Min(0) int page,
             @RequestParam(defaultValue = "10") @Min(1) @Max(100) int size,
             @RequestParam(defaultValue = "firstName") String sortBy,
             @RequestParam(defaultValue = "asc") String sortDirection,
             EmployeeFilterRequest filterRequest
-    ){
+    ) {
         PaginatedResponse<ListEmployeeResponse> result = employeeService.listAllEmployees(
-                page,size,sortBy,sortDirection, filterRequest);
+                page, size, sortBy, sortDirection, filterRequest);
 
         return ResponseEntity.ok(ApiResponse.success("Employees retrieved successfully", result));
     }
@@ -81,8 +73,8 @@ public class EmployeeController {
     )
     @GetMapping("/{id}")
     @PreAuthorize("hasAnyAuthority('ROLE_HR', 'ROLE_MANAGER')")
-    public ResponseEntity<ApiResponse<EmployeeDetailResponse>> getEmployee(@PathVariable("id") UUID employeeId){
-        return ResponseEntity.ok(ApiResponse.success( employeeService.getEmployeeById(employeeId)));
+    public ResponseEntity<ApiResponse<EmployeeDetailResponse>> getEmployee(@PathVariable("id") UUID employeeId) {
+        return ResponseEntity.ok(ApiResponse.success(employeeService.getEmployeeById(employeeId)));
     }
 
 
@@ -92,95 +84,31 @@ public class EmployeeController {
     )
     @PutMapping("/{id}")
     @PreAuthorize("hasAnyAuthority('ROLE_EMPLOYEE')")
-    public  ResponseEntity<ApiResponse<EmployeeDetailResponse>> updateEmployee(
+    public ResponseEntity<ApiResponse<EmployeeDetailResponse>> updateEmployee(
             @PathVariable("id") UUID employeeIdToUpdate,
             @Valid @RequestBody EmployeeUpdateRequest updateRequest,
             @AuthenticationPrincipal UserDetails currentUser
-            ){
+    ) {
         String updaterEmail = currentUser.getUsername();
         return ResponseEntity.ok(ApiResponse.success("Updated successfully", employeeService.updateEmployee(employeeIdToUpdate, updateRequest, updaterEmail)));
     }
 
+
     @Operation(
-            summary = "Get employee salary history",
-            description = "Retrieves the salary history for a specific employee by ID. Accessible only to HR and Manager roles."
+            summary = "Get all employees for a department",
+            description = "Retrieves a list of all employees working in a specific department. Accessible to HR and Manager roles."
     )
-    @GetMapping("/{id}/salaries")
+    @GetMapping("/department/{id}")
     @PreAuthorize("hasAnyAuthority('ROLE_HR', 'ROLE_MANAGER')")
-    public ResponseEntity<ApiResponse<PaginatedResponse<ListSalaryResponse>>> getEmployeeSalaryHistory(
-            @PathVariable("id") UUID id,
-            @RequestParam(defaultValue = "0") @Min(0) int page ,
+    public ResponseEntity<ApiResponse<PaginatedResponse<ListEmployeeResponse>>> getEmployeesByDepartment(
+            @PathVariable("id") UUID departmentId,
+            @RequestParam(defaultValue = "0") @Min(0) int page,
             @RequestParam(defaultValue = "10") @Min(1) @Max(100) int size,
-            @RequestParam(defaultValue = "effectiveDate") String sortBy,
-            @RequestParam(defaultValue = "desc") String sortDirection,
-            SalaryFilterRequest filterRequest
-    ){
-        PaginatedResponse<ListSalaryResponse> responseList = employeeService
-                .getEmployeeSalaryHistory(id,page,size,sortBy,sortDirection,filterRequest);
-
-        return ResponseEntity.ok(ApiResponse.success(responseList));
-    }
-
-
-    @Operation(
-            summary = "Get performance history for a specific employee",
-            description = "Retrieves a list of performance reviews for a specified employee by ID. This action is restricted to users with the HR or Manager role.")
-    @GetMapping("/{id}/performance-history")
-    @PreAuthorize("hasAnyAuthority('ROLE_HR', 'ROLE_MANAGER')")
-    public  ResponseEntity<ApiResponse<PaginatedResponse<ListPerformanceReviewResponse>>> getEmployeePerformanceHistory(
-            @PathVariable("id") UUID employeeId,
-            @RequestParam(defaultValue = "0") @Min(0) int page ,
-            @RequestParam(defaultValue = "10") @Min(1) @Max(100) int size,
-            @RequestParam(defaultValue = "reviewDate") String sortBy,
-            @RequestParam(defaultValue = "desc") String sortDirection,
-            PerformanceReviewFilterRequest filterRequest
-    ){
-        PaginatedResponse<ListPerformanceReviewResponse> responseList =
-                employeeService.getPerformanceReviewsByEmployeeId(employeeId, page, size, sortBy, sortDirection,filterRequest);
-
-        return ResponseEntity.ok(ApiResponse.success("Performance reviews retrieved successfully", responseList));
-    }
-
-    @Operation(
-            summary = "Get employee attendance history",
-            description = "Retrieves the attendance history for a specific employee by ID. Accessible only to HR and Manager roles."
-    )
-    @GetMapping("/{id}/attendance-history")
-    @PreAuthorize("hasAnyAuthority('ROLE_HR', 'ROLE_MANAGER')")
-    public ResponseEntity<ApiResponse<PaginatedResponse<ListAttendanceResponse>>> getEmployeeAttendanceHistory(
-            @PathVariable("id") UUID id,
-            @RequestParam(defaultValue = "0") @Min(0) int page ,
-            @RequestParam(defaultValue = "10") @Min(1) @Max(100) int size,
-            @RequestParam(defaultValue = "date") String sortBy,
+            @RequestParam(defaultValue = "firstName") String sortBy,
             @RequestParam(defaultValue = "asc") String sortDirection,
-            AttendanceFilterRequest filterRequest
-    ){
-        PaginatedResponse<ListAttendanceResponse> responseList = employeeService
-                .getAllAttendanceByEmployeeId(id,page,size,sortBy,sortDirection,filterRequest);
-
-        return  ResponseEntity.ok(ApiResponse.success(responseList));
-    }
-
-    @Operation(
-            summary = "Get an employee's leave balance",
-            description = "Retrieves the leave balance (vacation and maternity) for a specific employee by ID. Accessible to HR, Manager, and the employee themselves.",
-            security = @SecurityRequirement(name = "bearerAuth")
-    )
-    @GetMapping("/{id}/leave-balance")
-    @PreAuthorize("hasAnyAuthority('ROLE_EMPLOYEE')")
-    public ResponseEntity<ApiResponse<EmployeeLeaveBalanceResponse>> getLeaveBalance(@PathVariable("id") UUID id) {
-        return ResponseEntity.ok(ApiResponse.success(employeeService.getLeaveBalance(id)));
-    }
-
-
-    @Operation(
-            summary = "Get authenticated user's leave balance",
-            description = "Retrieves the leave balance for the authenticated user only. Accessible to all employees.",
-            security = @SecurityRequirement(name = "bearerAuth"))
-    @GetMapping("/my-leave-balance")
-    @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<ApiResponse<EmployeeLeaveBalanceResponse>> getMyLeaveBalance(@AuthenticationPrincipal UserDetails currentUser) {
-        Employee employee = employeeService.getEmployeeEntityByEmail(currentUser.getUsername());
-        return ResponseEntity.ok(ApiResponse.success(employeeService.getLeaveBalance(employee.getId())));
+            EmployeeFilterRequest filterRequest
+    ) {
+        PaginatedResponse<ListEmployeeResponse> responseList = employeeService.getEmployeesByDepartment(departmentId, page, size, sortBy, sortDirection, filterRequest);
+        return ResponseEntity.ok(ApiResponse.success("Employees retrieved for department successfully", responseList));
     }
 }

--- a/src/main/java/com/furkanerd/hr_management_system/controller/PerformanceReviewController.java
+++ b/src/main/java/com/furkanerd/hr_management_system/controller/PerformanceReviewController.java
@@ -43,14 +43,14 @@ public class PerformanceReviewController {
     )
     @GetMapping
     @PreAuthorize("hasAnyAuthority('ROLE_HR', 'ROLE_MANAGER')")
-    public ResponseEntity<ApiResponse<PaginatedResponse<ListPerformanceReviewResponse>>> getAllReviews (
-            @RequestParam(defaultValue = "0") @Min(0) int page ,
+    public ResponseEntity<ApiResponse<PaginatedResponse<ListPerformanceReviewResponse>>> getAllReviews(
+            @RequestParam(defaultValue = "0") @Min(0) int page,
             @RequestParam(defaultValue = "10") @Min(1) @Max(100) int size,
             @RequestParam(defaultValue = "reviewDate") String sortBy,
             @RequestParam(defaultValue = "desc") String sortDirection,
             PerformanceReviewFilterRequest filterRequest
-    ){
-        PaginatedResponse<ListPerformanceReviewResponse> responseList = performanceReviewService.listAllPerformanceReviews(page,size,sortBy,sortDirection,filterRequest);
+    ) {
+        PaginatedResponse<ListPerformanceReviewResponse> responseList = performanceReviewService.listAllPerformanceReviews(page, size, sortBy, sortDirection, filterRequest);
         return ResponseEntity.ok(ApiResponse.success("Performance reviews retrieved successfully", responseList));
     }
 
@@ -74,14 +74,33 @@ public class PerformanceReviewController {
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ApiResponse<PaginatedResponse<ListPerformanceReviewResponse>>> getMyReviews(
             @AuthenticationPrincipal UserDetails currentUser,
-            @RequestParam(defaultValue = "0") @Min(0) int page ,
+            @RequestParam(defaultValue = "0") @Min(0) int page,
             @RequestParam(defaultValue = "10") @Min(1) @Max(100) int size,
             @RequestParam(defaultValue = "reviewDate") String sortBy,
             @RequestParam(defaultValue = "desc") String sortDirection,
             PerformanceReviewFilterRequest filterRequest
-    ){
-        PaginatedResponse<ListPerformanceReviewResponse> responseList = performanceReviewService.getMyPerformanceReviews(currentUser.getUsername(),page,size,sortBy,sortDirection,filterRequest);
+    ) {
+        PaginatedResponse<ListPerformanceReviewResponse> responseList = performanceReviewService.getMyPerformanceReviews(currentUser.getUsername(), page, size, sortBy, sortDirection, filterRequest);
         return ResponseEntity.ok(ApiResponse.success("My performance reviews retrieved successfully", responseList));
+    }
+
+
+    @Operation(
+            summary = "Get performance history for a specific employee",
+            description = "Retrieves a list of performance reviews for a specified employee by ID. This action is restricted to users with the HR or Manager role.")
+    @GetMapping("/employee/{id}")
+    @PreAuthorize("hasAnyAuthority('ROLE_HR', 'ROLE_MANAGER')")
+    public ResponseEntity<ApiResponse<PaginatedResponse<ListPerformanceReviewResponse>>> getEmployeePerformanceHistory(
+            @PathVariable("id") UUID id,
+            @RequestParam(defaultValue = "0") @Min(0) int page,
+            @RequestParam(defaultValue = "10") @Min(1) @Max(100) int size,
+            @RequestParam(defaultValue = "reviewDate") String sortBy,
+            @RequestParam(defaultValue = "desc") String sortDirection,
+            PerformanceReviewFilterRequest filterRequest
+    ) {
+        PaginatedResponse<ListPerformanceReviewResponse> responseList =
+                performanceReviewService.getPerformanceReviewsByEmployee(id, page, size, sortBy, sortDirection, filterRequest);
+        return ResponseEntity.ok(ApiResponse.success("Performance reviews retrieved successfully", responseList));
     }
 
 
@@ -94,7 +113,7 @@ public class PerformanceReviewController {
     public ResponseEntity<ApiResponse<PerformanceReviewDetailResponse>> createReview(
             @Valid @RequestBody PerformanceReviewCreateRequest createRequest,
             @AuthenticationPrincipal UserDetails userDetails
-            ){
+    ) {
         String email = userDetails.getUsername();
         PerformanceReviewDetailResponse created = performanceReviewService.createPerformanceReview(createRequest, email);
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -113,7 +132,7 @@ public class PerformanceReviewController {
             @Valid @RequestBody PerformanceReviewUpdateRequest updateRequest,
             @AuthenticationPrincipal UserDetails currentUser) {
         String reviewerEmail = currentUser.getUsername();
-        PerformanceReviewDetailResponse updated =  performanceReviewService.updatePerformanceReview(id, updateRequest, reviewerEmail);
+        PerformanceReviewDetailResponse updated = performanceReviewService.updatePerformanceReview(id, updateRequest, reviewerEmail);
         return ResponseEntity.ok(ApiResponse.success("Performance review updated successfully", updated));
     }
 

--- a/src/main/java/com/furkanerd/hr_management_system/controller/SalaryController.java
+++ b/src/main/java/com/furkanerd/hr_management_system/controller/SalaryController.java
@@ -41,14 +41,14 @@ public class SalaryController {
     @GetMapping
     @PreAuthorize("hasAuthority('ROLE_HR')")
     public ResponseEntity<ApiResponse<PaginatedResponse<ListSalaryResponse>>> getSalaries(
-            @RequestParam(defaultValue = "0") @Min(0) int page ,
+            @RequestParam(defaultValue = "0") @Min(0) int page,
             @RequestParam(defaultValue = "10") @Min(1) @Max(100) int size,
             @RequestParam(defaultValue = "effectiveDate") String sortBy,
             @RequestParam(defaultValue = "desc") String sortDirection,
             SalaryFilterRequest filterRequest
 
-    ){
-        PaginatedResponse<ListSalaryResponse> responseList = salaryService.listAllSalaries(page,size,sortBy,sortDirection,filterRequest);
+    ) {
+        PaginatedResponse<ListSalaryResponse> responseList = salaryService.listAllSalaries(page, size, sortBy, sortDirection, filterRequest);
         return ResponseEntity.ok(ApiResponse.success(responseList));
     }
 
@@ -59,8 +59,26 @@ public class SalaryController {
     )
     @GetMapping("/{id}")
     @PreAuthorize("hasAuthority('ROLE_HR')")
-    public ResponseEntity<ApiResponse<SalaryDetailResponse>> getSalary(@PathVariable("id") UUID id){
+    public ResponseEntity<ApiResponse<SalaryDetailResponse>> getSalary(@PathVariable("id") UUID id) {
         return ResponseEntity.ok(ApiResponse.success(salaryService.getSalaryById(id)));
+    }
+
+    @Operation(
+            summary = "Get employee salary history",
+            description = "Retrieves the salary history for a specific employee by ID. Accessible only to HR and Manager roles."
+    )
+    @GetMapping("/employee/{id}")
+    @PreAuthorize("hasAnyAuthority('ROLE_HR', 'ROLE_MANAGER')")
+    public ResponseEntity<ApiResponse<PaginatedResponse<ListSalaryResponse>>> getSalaryHistoryByEmployee(
+            @PathVariable("id") UUID id,
+            @RequestParam(defaultValue = "0") @Min(0) int page,
+            @RequestParam(defaultValue = "10") @Min(1) @Max(100) int size,
+            @RequestParam(defaultValue = "effectiveDate") String sortBy,
+            @RequestParam(defaultValue = "desc") String sortDirection,
+            SalaryFilterRequest filterRequest
+    ) {
+        PaginatedResponse<ListSalaryResponse> responseList = salaryService.getSalaryHistoryByEmployee(id, page, size, sortBy, sortDirection, filterRequest);
+        return ResponseEntity.ok(ApiResponse.success(responseList));
     }
 
     @Operation(
@@ -84,14 +102,14 @@ public class SalaryController {
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ApiResponse<PaginatedResponse<ListSalaryResponse>>> getMySalaryHistory(
             @AuthenticationPrincipal UserDetails currentUser,
-            @RequestParam(defaultValue = "0") @Min(0) int page ,
+            @RequestParam(defaultValue = "0") @Min(0) int page,
             @RequestParam(defaultValue = "10") @Min(1) @Max(100) int size,
             @RequestParam(defaultValue = "effectiveDate") String sortBy,
             @RequestParam(defaultValue = "desc") String sortDirection,
             SalaryFilterRequest filterRequest
-    ){
+    ) {
         String email = currentUser.getUsername();
-        PaginatedResponse<ListSalaryResponse> responseList = salaryService.showEmployeeSalaryHistory(email,page,size,sortBy,sortDirection,filterRequest);
+        PaginatedResponse<ListSalaryResponse> responseList = salaryService.showEmployeeSalaryHistory(email, page, size, sortBy, sortDirection, filterRequest);
         return ResponseEntity.ok(ApiResponse.success(responseList));
     }
 
@@ -101,7 +119,7 @@ public class SalaryController {
     )
     @DeleteMapping("/{id}")
     @PreAuthorize("hasAuthority('ROLE_HR')")
-    public ResponseEntity<ApiResponse<Void>> deleteSalary(@PathVariable("id") UUID id){
+    public ResponseEntity<ApiResponse<Void>> deleteSalary(@PathVariable("id") UUID id) {
         salaryService.deleteSalary(id);
         return ResponseEntity.ok(ApiResponse.success("Salary deleted successfully"));
     }

--- a/src/main/java/com/furkanerd/hr_management_system/helper/EmployeeDomainService.java
+++ b/src/main/java/com/furkanerd/hr_management_system/helper/EmployeeDomainService.java
@@ -2,19 +2,10 @@ package com.furkanerd.hr_management_system.helper;
 
 import com.furkanerd.hr_management_system.exception.EmployeeNotFoundException;
 import com.furkanerd.hr_management_system.mapper.EmployeeMapper;
-import com.furkanerd.hr_management_system.model.dto.request.employee.EmployeeFilterRequest;
-import com.furkanerd.hr_management_system.model.dto.response.PaginatedResponse;
-import com.furkanerd.hr_management_system.model.dto.response.employee.ListEmployeeResponse;
 import com.furkanerd.hr_management_system.model.entity.Employee;
 import com.furkanerd.hr_management_system.repository.EmployeeRepository;
-import com.furkanerd.hr_management_system.specification.EmployeeSpecification;
-import com.furkanerd.hr_management_system.util.PaginationUtils;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -36,36 +27,5 @@ public class EmployeeDomainService {
     public Employee getEmployeeByEmail(String email) {
         return employeeRepository.findByEmail(email)
                 .orElseThrow(() -> new EmployeeNotFoundException(email));
-    }
-
-    public PaginatedResponse<ListEmployeeResponse> getEmployeesByDepartmentId(UUID departmentId, int page, int size, String sortBy, String sortDirection, EmployeeFilterRequest filterRequest) {
-        String validatedSortBy = validateSortField(sortBy);
-        Pageable pageable = PaginationUtils.buildPageable(page,size,validatedSortBy,sortDirection);
-
-        Specification<Employee> specification = EmployeeSpecification.withFilters(filterRequest);
-        Specification<Employee> departmentIdSpec = (root, query, cb) -> cb.equal(root.get("department").get("id"), departmentId);
-
-        Specification<Employee> combinedSpec = (specification != null)
-                ? specification.and(departmentIdSpec)
-                : departmentIdSpec;
-
-        Page<Employee> employeePage = employeeRepository.findAll(combinedSpec,pageable);
-        List<ListEmployeeResponse> responseList = employeeMapper.employeestoListEmployeeResponseList(employeePage.getContent());
-
-        return PaginatedResponse.of(
-                responseList,
-                employeePage.getTotalElements(),
-                page,
-                size
-        );
-    }
-
-    /**
-     * Validates the sortBy field to ensure it matches allowed fields for sorting.
-     * This prevents malicious input that could manipulate the generated SQL query.
-     */
-    private String validateSortField(String sortBy) {
-        List<String> validFields = List.of("id", "firstName", "lastName", "email", "phone", "hireDate","birthDate","address", "status", "role","createdAt", "updatedAt");
-        return validFields.contains(sortBy) ? sortBy : "firstName";
     }
 }

--- a/src/main/java/com/furkanerd/hr_management_system/mapper/EmployeeMapper.java
+++ b/src/main/java/com/furkanerd/hr_management_system/mapper/EmployeeMapper.java
@@ -1,7 +1,6 @@
 package com.furkanerd.hr_management_system.mapper;
 
 import com.furkanerd.hr_management_system.model.dto.response.employee.EmployeeDetailResponse;
-import com.furkanerd.hr_management_system.model.dto.response.employee.EmployeeLeaveBalanceResponse;
 import com.furkanerd.hr_management_system.model.dto.response.employee.ListEmployeeResponse;
 import com.furkanerd.hr_management_system.model.entity.Employee;
 import org.mapstruct.Mapper;
@@ -25,9 +24,6 @@ public interface EmployeeMapper {
     @Mapping(target = "positionTitle",source = "employee.position.title")
     @Mapping(target = "managerFullName",expression = "java(getManagerFullName(employee))")
     EmployeeDetailResponse  toEmployeeDetailResponse(Employee employee);
-
-    @Mapping(target = "employeeId",source = "id")
-    EmployeeLeaveBalanceResponse toEmployeeLeaveBalanceResponse(Employee employee);
 
     default String getEmployeeFullName(Employee employee) {
         return employee.getFirstName() + " " + employee.getLastName();

--- a/src/main/java/com/furkanerd/hr_management_system/mapper/LeaveRequestMapper.java
+++ b/src/main/java/com/furkanerd/hr_management_system/mapper/LeaveRequestMapper.java
@@ -1,7 +1,9 @@
 package com.furkanerd.hr_management_system.mapper;
 
+import com.furkanerd.hr_management_system.model.dto.response.employee.EmployeeLeaveBalanceResponse;
 import com.furkanerd.hr_management_system.model.dto.response.leaverequest.LeaveRequestDetailResponse;
 import com.furkanerd.hr_management_system.model.dto.response.leaverequest.ListLeaveRequestResponse;
+import com.furkanerd.hr_management_system.model.entity.Employee;
 import com.furkanerd.hr_management_system.model.entity.LeaveRequest;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -25,6 +27,9 @@ public interface LeaveRequestMapper {
     @Mapping(target = "positionName",source = "leaveRequest.employee.position.title")
     @Mapping(target = "approverName", expression = "java(getApproverFullName(leaveRequest))")
     LeaveRequestDetailResponse leaveRequestToLeaveRequestDetailResponse(LeaveRequest leaveRequest);
+
+    @Mapping(target = "employeeId",source = "id")
+    EmployeeLeaveBalanceResponse toEmployeeLeaveBalanceResponse(Employee employee);
 
     default String getFullName(LeaveRequest leaveRequest) {
         return leaveRequest.getEmployee().getFirstName() + " " + leaveRequest.getEmployee().getLastName();

--- a/src/main/java/com/furkanerd/hr_management_system/service/AttendanceService.java
+++ b/src/main/java/com/furkanerd/hr_management_system/service/AttendanceService.java
@@ -29,5 +29,5 @@ public interface AttendanceService {
 
     void deleteAttendance(UUID id);
 
-    PaginatedResponse<ListAttendanceResponse> getAttendanceByEmployeeId(UUID id, int page, int size, String sortBy, String sortDirection, AttendanceFilterRequest filterRequest);
+    PaginatedResponse<ListAttendanceResponse> getAllAttendanceByEmployee(UUID id, int page, int size, String sortBy, String sortDirection, AttendanceFilterRequest filterRequest);
 }

--- a/src/main/java/com/furkanerd/hr_management_system/service/DepartmentService.java
+++ b/src/main/java/com/furkanerd/hr_management_system/service/DepartmentService.java
@@ -3,11 +3,9 @@ package com.furkanerd.hr_management_system.service;
 import com.furkanerd.hr_management_system.model.dto.request.department.DepartmentCreateRequest;
 import com.furkanerd.hr_management_system.model.dto.request.department.DepartmentFilterRequest;
 import com.furkanerd.hr_management_system.model.dto.request.department.DepartmentUpdateRequest;
-import com.furkanerd.hr_management_system.model.dto.request.employee.EmployeeFilterRequest;
 import com.furkanerd.hr_management_system.model.dto.response.PaginatedResponse;
 import com.furkanerd.hr_management_system.model.dto.response.department.DepartmentDetailResponse;
 import com.furkanerd.hr_management_system.model.dto.response.department.ListDepartmentResponse;
-import com.furkanerd.hr_management_system.model.dto.response.employee.ListEmployeeResponse;
 import com.furkanerd.hr_management_system.model.entity.Department;
 
 import java.util.UUID;
@@ -17,8 +15,6 @@ public interface DepartmentService {
     PaginatedResponse<ListDepartmentResponse> listAllDepartments(int page, int size,String sortBy,String sortDirection, DepartmentFilterRequest filterRequest);
 
     DepartmentDetailResponse getDepartmentById(UUID id);
-
-    PaginatedResponse<ListEmployeeResponse> getEmployeesByDepartment(UUID departmentId,int page,int size,String sortBy,String sortDirection, EmployeeFilterRequest filterRequest);
 
     DepartmentDetailResponse createDepartment(DepartmentCreateRequest createRequest);
 

--- a/src/main/java/com/furkanerd/hr_management_system/service/EmployeeService.java
+++ b/src/main/java/com/furkanerd/hr_management_system/service/EmployeeService.java
@@ -1,20 +1,12 @@
 package com.furkanerd.hr_management_system.service;
 
-import com.furkanerd.hr_management_system.model.dto.request.attendance.AttendanceFilterRequest;
 import com.furkanerd.hr_management_system.model.dto.request.employee.EmployeeFilterRequest;
 import com.furkanerd.hr_management_system.model.dto.request.employee.EmployeeUpdateRequest;
-import com.furkanerd.hr_management_system.model.dto.request.performancereview.PerformanceReviewFilterRequest;
-import com.furkanerd.hr_management_system.model.dto.request.salary.SalaryFilterRequest;
 import com.furkanerd.hr_management_system.model.dto.response.PaginatedResponse;
-import com.furkanerd.hr_management_system.model.dto.response.attendance.ListAttendanceResponse;
 import com.furkanerd.hr_management_system.model.dto.response.employee.EmployeeDetailResponse;
-import com.furkanerd.hr_management_system.model.dto.response.employee.EmployeeLeaveBalanceResponse;
 import com.furkanerd.hr_management_system.model.dto.response.employee.ListEmployeeResponse;
-import com.furkanerd.hr_management_system.model.dto.response.performancereview.ListPerformanceReviewResponse;
-import com.furkanerd.hr_management_system.model.dto.response.salary.ListSalaryResponse;
 import com.furkanerd.hr_management_system.model.entity.Employee;
 
-import java.util.List;
 import java.util.UUID;
 
 public interface EmployeeService {
@@ -31,17 +23,7 @@ public interface EmployeeService {
 
     Employee getEmployeeEntityById(UUID id);
 
-    boolean emailExists(String email);
-
-    boolean phoneExists(String phone);
-
-    PaginatedResponse<ListSalaryResponse> getEmployeeSalaryHistory(UUID employeeId, int page, int size, String sortBy, String sortDirection, SalaryFilterRequest filterRequest);
-
-    PaginatedResponse<ListPerformanceReviewResponse> getPerformanceReviewsByEmployeeId(UUID employeeId, int page, int size, String sortBy, String sortDirection, PerformanceReviewFilterRequest filterRequest);
-
-    PaginatedResponse<ListAttendanceResponse> getAllAttendanceByEmployeeId(UUID id, int page, int size, String sortBy, String sortDirection, AttendanceFilterRequest filterRequest);
-
-    EmployeeLeaveBalanceResponse getLeaveBalance(UUID employeeId);
-
     void saveEmployee(Employee employee);
+
+    PaginatedResponse<ListEmployeeResponse> getEmployeesByDepartment(UUID departmentId,int page,int size,String sortBy,String sortDirection, EmployeeFilterRequest filterRequest);
 }

--- a/src/main/java/com/furkanerd/hr_management_system/service/LeaveRequestService.java
+++ b/src/main/java/com/furkanerd/hr_management_system/service/LeaveRequestService.java
@@ -4,6 +4,7 @@ import com.furkanerd.hr_management_system.model.dto.request.leaverequest.LeaveRe
 import com.furkanerd.hr_management_system.model.dto.request.leaverequest.LeaveRequestEditRequest;
 import com.furkanerd.hr_management_system.model.dto.request.leaverequest.LeaveRequestFilterRequest;
 import com.furkanerd.hr_management_system.model.dto.response.PaginatedResponse;
+import com.furkanerd.hr_management_system.model.dto.response.employee.EmployeeLeaveBalanceResponse;
 import com.furkanerd.hr_management_system.model.dto.response.leaverequest.LeaveRequestDetailResponse;
 import com.furkanerd.hr_management_system.model.dto.response.leaverequest.ListLeaveRequestResponse;
 
@@ -27,4 +28,8 @@ public interface LeaveRequestService {
     LeaveRequestDetailResponse rejectLeaveRequest(UUID leaveRequestId, String approverEmail);
 
     void cancelLeaveRequest(UUID leaveRequestId, String requesterEmail);
+
+    EmployeeLeaveBalanceResponse getMyLeaveBalance(String email);
+
+    EmployeeLeaveBalanceResponse getEmployeeLeaveBalance(UUID employeeId);
 }

--- a/src/main/java/com/furkanerd/hr_management_system/service/PerformanceReviewService.java
+++ b/src/main/java/com/furkanerd/hr_management_system/service/PerformanceReviewService.java
@@ -23,5 +23,5 @@ public interface PerformanceReviewService {
 
     void deletePerformanceReview(UUID id, String reviewerEmail);
 
-    PaginatedResponse<ListPerformanceReviewResponse> getPerformanceReviewByEmployeeId(UUID employeeId, int page, int size, String sortBy, String sortDirection, PerformanceReviewFilterRequest filterRequest);
+    PaginatedResponse<ListPerformanceReviewResponse> getPerformanceReviewsByEmployee(UUID employeeId, int page, int size, String sortBy, String sortDirection, PerformanceReviewFilterRequest filterRequest);
 }

--- a/src/main/java/com/furkanerd/hr_management_system/service/SalaryService.java
+++ b/src/main/java/com/furkanerd/hr_management_system/service/SalaryService.java
@@ -21,5 +21,5 @@ public interface SalaryService {
 
     void deleteSalary(UUID id);
 
-    PaginatedResponse<ListSalaryResponse> getEmployeeSalaryHistory(UUID employeeId, int page, int size, String sortBy, String sortDirection, SalaryFilterRequest filterRequest);
+    PaginatedResponse<ListSalaryResponse> getSalaryHistoryByEmployee(UUID employeeId, int page, int size, String sortBy, String sortDirection, SalaryFilterRequest filterRequest);
 }

--- a/src/main/java/com/furkanerd/hr_management_system/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/furkanerd/hr_management_system/service/impl/AuthServiceImpl.java
@@ -41,7 +41,7 @@ class AuthServiceImpl implements AuthService {
     private final DepartmentService departmentService;
     private final PositionService positionService;
 
-    public AuthServiceImpl(AuthenticationManager authenticationManager, UserDetailsService userDetailsService, PasswordEncoder passwordEncoder, JwtUtil jwtUtil, EmployeeRepository employeeRepository,DepartmentService departmentService, PositionService positionService) {
+    public AuthServiceImpl(AuthenticationManager authenticationManager, UserDetailsService userDetailsService, PasswordEncoder passwordEncoder, JwtUtil jwtUtil, EmployeeRepository employeeRepository, DepartmentService departmentService, PositionService positionService) {
         this.authenticationManager = authenticationManager;
         this.userDetailsService = userDetailsService;
         this.passwordEncoder = passwordEncoder;
@@ -81,23 +81,23 @@ class AuthServiceImpl implements AuthService {
                             .collect(Collectors.toList()))
                     .mustChangePassword(employee.isMustChangePassword())
                     .build();
-        }catch (BadCredentialsException e){
+        } catch (BadCredentialsException e) {
             throw new BadCredentialsException("Invalid username or password", e);
         }
     }
 
     @Override
     @Transactional
-    public RegisterResponse register(RegisterRequest registerRequest){
+    public RegisterResponse register(RegisterRequest registerRequest) {
 
-        if (employeeRepository.existsByEmail(registerRequest.email())){
-            throw new EmailAlreadyExistsException("Email already exists: "+ registerRequest.email());
+        if (employeeRepository.existsByEmail(registerRequest.email())) {
+            throw new EmailAlreadyExistsException("Email already exists: " + registerRequest.email());
         }
 
-        if(registerRequest.phone() != null &&
+        if (registerRequest.phone() != null &&
                 !registerRequest.phone().trim().isEmpty() &&
-                employeeRepository.existsByPhone(registerRequest.phone())){
-            throw new PhoneNumberAlreadyExistsException("Phone number already exists: "+ registerRequest.phone());
+                employeeRepository.existsByPhone(registerRequest.phone())) {
+            throw new PhoneNumberAlreadyExistsException("Phone number already exists: " + registerRequest.phone());
         }
 
         // Set the default password for the first time
@@ -143,21 +143,21 @@ class AuthServiceImpl implements AuthService {
 
             employee.setManager(manager);
         }
-         Employee savedEmployee = employeeRepository.save(employee);
-         return new RegisterResponse(
-                 savedEmployee.getId(),
-                 savedEmployee.getEmail(),
-                 savedEmployee.getFirstName(),
-                 savedEmployee.getLastName(),
-                 savedEmployee.getRole(),
-                 tempPassword,
-                 List.of(savedEmployee.getRole().name())
-         );
+        Employee savedEmployee = employeeRepository.save(employee);
+        return new RegisterResponse(
+                savedEmployee.getId(),
+                savedEmployee.getEmail(),
+                savedEmployee.getFirstName(),
+                savedEmployee.getLastName(),
+                savedEmployee.getRole(),
+                tempPassword,
+                List.of(savedEmployee.getRole().name())
+        );
     }
 
     @Override
     @Transactional
-    public void changePassword(String email, String oldPassword, String newPassword){
+    public void changePassword(String email, String oldPassword, String newPassword) {
         Employee employee = employeeRepository.findByEmail(email)
                 .orElseThrow(() -> new ResourceNotFoundException("Employee not found"));
 

--- a/src/main/java/com/furkanerd/hr_management_system/service/impl/DepartmentServiceImpl.java
+++ b/src/main/java/com/furkanerd/hr_management_system/service/impl/DepartmentServiceImpl.java
@@ -1,16 +1,13 @@
 package com.furkanerd.hr_management_system.service.impl;
 
 import com.furkanerd.hr_management_system.exception.DepartmentNotFoundException;
-import com.furkanerd.hr_management_system.helper.EmployeeDomainService;
 import com.furkanerd.hr_management_system.mapper.DepartmentMapper;
 import com.furkanerd.hr_management_system.model.dto.request.department.DepartmentCreateRequest;
 import com.furkanerd.hr_management_system.model.dto.request.department.DepartmentFilterRequest;
 import com.furkanerd.hr_management_system.model.dto.request.department.DepartmentUpdateRequest;
-import com.furkanerd.hr_management_system.model.dto.request.employee.EmployeeFilterRequest;
 import com.furkanerd.hr_management_system.model.dto.response.PaginatedResponse;
 import com.furkanerd.hr_management_system.model.dto.response.department.DepartmentDetailResponse;
 import com.furkanerd.hr_management_system.model.dto.response.department.ListDepartmentResponse;
-import com.furkanerd.hr_management_system.model.dto.response.employee.ListEmployeeResponse;
 import com.furkanerd.hr_management_system.model.entity.Department;
 import com.furkanerd.hr_management_system.repository.DepartmentRepository;
 import com.furkanerd.hr_management_system.service.DepartmentService;
@@ -31,23 +28,21 @@ class DepartmentServiceImpl implements DepartmentService {
 
     private final DepartmentRepository departmentRepository;
     private final DepartmentMapper departmentMapper;
-    private final EmployeeDomainService employeeDomainService;
 
-    public DepartmentServiceImpl(DepartmentRepository departmentRepository, DepartmentMapper departmentMapper, EmployeeDomainService employeeDomainService) {
+    public DepartmentServiceImpl(DepartmentRepository departmentRepository, DepartmentMapper departmentMapper) {
         this.departmentRepository = departmentRepository;
         this.departmentMapper = departmentMapper;
-        this.employeeDomainService = employeeDomainService;
     }
 
 
     @Override
-    public PaginatedResponse<ListDepartmentResponse> listAllDepartments(int page,int size,String sortBy,String sortDirection,DepartmentFilterRequest filterRequest) {
-        String validatedSortBy = SortFieldValidator.validate("department",sortBy);
-        Pageable pageable = PaginationUtils.buildPageable(page,size,validatedSortBy,sortDirection);
+    public PaginatedResponse<ListDepartmentResponse> listAllDepartments(int page, int size, String sortBy, String sortDirection, DepartmentFilterRequest filterRequest) {
+        String validatedSortBy = SortFieldValidator.validate("department", sortBy);
+        Pageable pageable = PaginationUtils.buildPageable(page, size, validatedSortBy, sortDirection);
 
         Specification<Department> specification = DepartmentSpecification.withFilters(filterRequest);
 
-        Page<Department> departmentPage = departmentRepository.findAll(specification,pageable);
+        Page<Department> departmentPage = departmentRepository.findAll(specification, pageable);
         List<ListDepartmentResponse> responseList = departmentMapper.departmentsToListDepartmentResponses(departmentPage.getContent());
         return PaginatedResponse.of(
                 responseList,
@@ -62,13 +57,6 @@ class DepartmentServiceImpl implements DepartmentService {
         Department department = departmentRepository.findById(id)
                 .orElseThrow(() -> new DepartmentNotFoundException(id));
         return departmentMapper.departmentToDepartmentDetailResponse(department);
-    }
-
-    @Override
-    public PaginatedResponse<ListEmployeeResponse> getEmployeesByDepartment(UUID departmentId,int page,int size,String sortBy,String sortDirection, EmployeeFilterRequest filterRequest) {
-        departmentRepository.findById(departmentId)
-                .orElseThrow(() -> new DepartmentNotFoundException(departmentId));
-        return employeeDomainService.getEmployeesByDepartmentId(departmentId,page,size,sortBy,sortDirection,filterRequest);
     }
 
     @Override
@@ -95,11 +83,11 @@ class DepartmentServiceImpl implements DepartmentService {
     @Override
     @Transactional
     public void deleteDepartment(UUID departmentId) {
-       boolean exists = departmentRepository.existsById(departmentId);
-       if (!exists) {
-           throw new  DepartmentNotFoundException(departmentId);
-       }
-       departmentRepository.deleteById(departmentId);
+        boolean exists = departmentRepository.existsById(departmentId);
+        if (!exists) {
+            throw new DepartmentNotFoundException(departmentId);
+        }
+        departmentRepository.deleteById(departmentId);
     }
 
     @Override

--- a/src/main/java/com/furkanerd/hr_management_system/service/impl/PositionServiceImpl.java
+++ b/src/main/java/com/furkanerd/hr_management_system/service/impl/PositionServiceImpl.java
@@ -39,7 +39,7 @@ class PositionServiceImpl implements PositionService {
         String validatedSortBy = SortFieldValidator.validate("position",sortBy);
         Pageable pageable = PaginationUtils.buildPageable(page,size,validatedSortBy,sortDirection);
 
-        Specification<Position> specification = PositionSpecification.withFilters(filterRequest);;
+        Specification<Position> specification = PositionSpecification.withFilters(filterRequest);
 
         Page<Position> positionPage = positionRepository.findAll(specification,pageable);
         List<ListPositionResponse> responseList = positionMapper.positionsToListPositionResponses(positionPage.getContent());


### PR DESCRIPTION
Reorganized controller endpoints by domain to improve project structure and readability.

Changes include:
- Attendance endpoints moved to AttendanceController:
  /api/v1/employees/{id}/attendance-history → /api/v1/attendance/employee/{id}

- Salary endpoints moved to SalaryController:
  /api/v1/employees/{id}/salaries → /api/v1/salaries/employee/{id}

- PerformanceReview endpoints moved to PerformanceReviewController:
  /api/v1/employees/{id}/performance-history → /api/v1/performance-reviews/employee/{id}

- Department-related employee endpoints moved/renamed:
  /api/v1/departments/{id}/employees → /api/v1/employees/department/{id}

- Leave balance endpoints moved to LeaveRequestController:
  /api/v1/employees/{id}/leave-balance → /api/v1/leaves/{employeeId}/balance
  /api/v1/employees/my-leave-balance → /api/v1/leaves/my-balance

- Updated related service methods and mappers to match new endpoints.

This refactor improves modularity and makes the API structure more consistent with domain boundaries.

closes #7